### PR TITLE
feat: support auto-generate stored credentials from store URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const mp = new MP({
 | -------- | -------- | ----------- | ----------------------------------------------------------------------------- |
 | `key`    | `string` | conditional | Your Store's API consumer key if token not provided this field is required    |
 | `secret` | `string` | conditional | Your Store's API consumer secret if token not provided this field is required |
-| `store`  | `string` | conditional | Your store current store URL |
+| `store`  | `string` | conditional | Your store current store URL                                                  |
 
 <small>https://knawat-mp.restlet.io/#operation_get_token</small>
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ Setup for the new Knawat Dropshipping REST API integration:
 ```javascript
 const MP = require('@knawat/mp');
 
+// Provide instance with your store credentials
 const mp = new MP({
   key: 'XXXXXXXXXXXXXXXXXXXXXXXXXXX',
   secret: 'XXXXXXXXXXXXXXXXXXXXXXXX',
-  token: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+});
+
+// Or use your store id/URL
+const mp = new MP({
+  store: 'XXXXXXXXXXXXXXXXXXXXXXXXXXX',
 });
 ```
 
@@ -54,7 +59,7 @@ const mp = new MP({
 | -------- | -------- | ----------- | ----------------------------------------------------------------------------- |
 | `key`    | `string` | conditional | Your Store's API consumer key if token not provided this field is required    |
 | `secret` | `string` | conditional | Your Store's API consumer secret if token not provided this field is required |
-| `token`  | `string` | conditional | Previous token if key and secret not provided this field is required          |
+| `store`  | `string` | conditional | Your store current store URL |
 
 <small>https://knawat-mp.restlet.io/#operation_get_token</small>
 

--- a/src/KnawatMP.js
+++ b/src/KnawatMP.js
@@ -25,7 +25,7 @@ class KnawatMP {
     this.secret = secret;
     this.store = store;
 
-    // for backward computability
+    // For backward compatibility
     this.consumerKey = key;
     this.consumerSecret = secret;
   }


### PR DESCRIPTION
This __PR__ aims mainly to support configuring MP SDK using the store URL.

## Motivation
In many cases, you need to use the SDK APIs but you have only the store URL. And the SDK supports only configuration through the store's secret and key.

Old way to use it
```js
const mpSDK = new MP();

const storeDoc = await mpSDK.getStoreByURL('https://mystore.com/');
const mpSDKBearer = new MP({
   key: storeDoc.consumerKey,
   secret: storeDoc.consumerSecret,
});
```

New way
```js
const mpSDK = new MP({
   store: 'https://mystore.com/',
});
```